### PR TITLE
Handle nulls in StringExtensions after upgrade to C# 8.0

### DIFF
--- a/Source/Toolbox/Toolbox.Extensions.Tests/A_String.cs
+++ b/Source/Toolbox/Toolbox.Extensions.Tests/A_String.cs
@@ -26,19 +26,5 @@ namespace Toolbox.Extensions.Tests
 
             Assert.AreEqual(expected, bytes);
         }
-
-        [Test]
-        public void Can_ToTitleCase_Handle_Null()
-        {
-            var actual = (null as string).ToTitleCase();
-            Assert.AreEqual(null, actual);
-        }
-
-        [Test]
-        public void Can_ToBytes_Handle_Null()
-        {
-            var actual = (null as string).ToBytes();
-            Assert.AreEqual(null, actual);
-        }
     }
 }

--- a/Source/Toolbox/Toolbox/Extensions/StringExtensions.cs
+++ b/Source/Toolbox/Toolbox/Extensions/StringExtensions.cs
@@ -11,21 +11,11 @@ namespace Toolbox.Extensions
     {
         public static string ToTitleCase(this string text)
         {
-            if (text is null)
-            {
-                return null;
-            }
-
             return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(text.ToLower());
         }
 
-        public static byte[] ToBytes(this string value, Encoding encoding = null)
+        public static byte[] ToBytes(this string value, Encoding? encoding = null)
         {
-            if (value is null)
-            {
-                return null;
-            }
-
             if (encoding is null)
             {
                 encoding = Encoding.UTF8;


### PR DESCRIPTION
GH-7