### PR TITLE
Adds ParallelForEachAsync to IEnumerableExtensions

### DIFF
--- a/Source/Toolbox/Toolbox/Collections/Generic/Extensions/IEnumerableExtensions.cs
+++ b/Source/Toolbox/Toolbox/Collections/Generic/Extensions/IEnumerableExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Toolbox.Collections.Concurrent;
 
 namespace Toolbox.Collections.Generic.Extensions
@@ -34,6 +36,25 @@ namespace Toolbox.Collections.Generic.Extensions
         public static IndexedEnumerable<TResult> AsIndexedEnumerable<TResult>(this IEnumerable<TResult> collection)
         {
             return new IndexedEnumerable<TResult>(collection);
+        }
+
+        public static IEnumerable<Task> ParallelForEachAsync<T>(this IEnumerable<T> enumerable, Action<T> action)
+        {
+            return enumerable.ParallelForEachAsync(action, Environment.ProcessorCount);
+        }
+
+        public static IEnumerable<Task> ParallelForEachAsync<T>(this IEnumerable<T> enumerable, Action<T> action, int processorCount)
+        {
+            var semaphore = new SemaphoreSlim(processorCount);
+
+            return enumerable.Select(async item =>
+            {
+                await semaphore.WaitAsync();
+
+                await Task.Run(() => action(item));
+
+                semaphore.Release();
+            });
         }
     }
 }


### PR DESCRIPTION
Parallel.ForEach does not function with async methods, this can be used as an alternative.